### PR TITLE
GH-5: Add ability to configure the plugin using system properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -231,7 +231,7 @@ The plugin may also be used and configured using the Maven CLI. Available config
 
 They are used like this:
 
-[source,shell]
+[source,shell,subs="+attributes"]
 ----
 mvn de.chkal.maven:gitlab-code-quality-plugin:{version_stable}:check \
     -Dglcqp.spotbugsEnabled=true \

--- a/README.adoc
+++ b/README.adoc
@@ -219,6 +219,28 @@ build:
         - merged-gl-code-quality-report.json
 ----
 
+== CLI usage
+
+The plugin may also be used and configured using the Maven CLI. Available configuration properties are:
+
+* `glcqp.spotbugsEnabled`
+* `glcqp.spotbugsInputFile`
+* `glcqp.checkstyleEnabled`
+* `glcqp.checkstyeInputFile`
+* `glcqp.outputFile`
+
+They are used like this:
+
+[source,shell]
+----
+mvn de.chkal.maven:gitlab-code-quality-plugin:{version_stable}:check \
+    -Dglcqp.spotbugsEnabled=true \
+    -Dglcqp.spotbugsInputFile=target/spotbugsXml.xml \
+    -Dglcqp.checkstyleEnabled=true \
+    -Dglcqp.checkstyeInputFile=target/checkstyle-result.xml \
+    -Dglcqp.outputFile=target/gl-code-quality-report.json
+----
+
 == Using the latest snapshots
 
 The latest snapshots of this plugin are deployed to the Sonatype OSSRH repository.

--- a/src/main/java/de/chkal/maven/gitlab/codequality/GenerateMojo.java
+++ b/src/main/java/de/chkal/maven/gitlab/codequality/GenerateMojo.java
@@ -20,19 +20,19 @@ import org.apache.maven.project.MavenProject;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class GenerateMojo extends AbstractMojo {
 
-  @Parameter(defaultValue = "true")
+  @Parameter(property = "glcqp.spotbugsEnabled", defaultValue = "true")
   public boolean spotbugsEnabled;
 
-  @Parameter(defaultValue = "${project.build.directory}/spotbugsXml.xml")
+  @Parameter(property = "glcqp.spotbugsInputFile", defaultValue = "${project.build.directory}/spotbugsXml.xml")
   public File spotbugsInputFile;
 
-  @Parameter(defaultValue = "true")
+  @Parameter(property = "glcqp.checkstyleEnabled", defaultValue = "true")
   public boolean checkstyleEnabled;
 
-  @Parameter(defaultValue = "${project.build.directory}/checkstyle-result.xml")
+  @Parameter(property = "glcqp.checkstyeInputFile", defaultValue = "${project.build.directory}/checkstyle-result.xml")
   public File checkstyleInputFile;
 
-  @Parameter(defaultValue = "${project.build.directory}/gl-code-quality-report.json")
+  @Parameter(property = "glcqp.outputFile", defaultValue = "${project.build.directory}/gl-code-quality-report.json")
   public File outputFile;
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)


### PR DESCRIPTION
Adds the ability to configure the plugin using system properties.

System propertiers are prefixed with `glcqp`to avoid conflicts with other plugins. The system property names correspond to the field names of the mojo.